### PR TITLE
Add typecheck for Formatter implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ func ExampleSimpleFormatter() {
 	// Output: http_requests_total, 100
 }
 
+var _ gometer.Formatter = (*simpleFormatter)(nil)
+
 type sortByNameFormatter struct{}
 
 func (f *sortByNameFormatter) Format(counters map[string]*gometer.Counter) []byte {
@@ -108,6 +110,8 @@ func (f *sortByNameFormatter) Format(counters map[string]*gometer.Counter) []byt
 
 	return buf.Bytes()
 }
+
+var _ gometer.Formatter = (*sortByNameFormatter)(nil)
 
 func ExampleSortByNameFormatter() {
 	metrics := gometer.New()

--- a/_examples/formatter_test.go
+++ b/_examples/formatter_test.go
@@ -20,6 +20,8 @@ func (f *simpleFormatter) Format(counters map[string]*gometer.Counter) []byte {
 	return buf.Bytes()
 }
 
+var _ gometer.Formatter = (*simpleFormatter)(nil)
+
 func ExampleSimpleFormatter() {
 	metrics := gometer.New()
 	metrics.SetOutput(os.Stdout)
@@ -54,6 +56,8 @@ func (f *sortByNameFormatter) Format(counters map[string]*gometer.Counter) []byt
 
 	return buf.Bytes()
 }
+
+var _ gometer.Formatter = (*sortByNameFormatter)(nil)
 
 func ExampleSortByNameFormatter() {
 	metrics := gometer.New()

--- a/formatter.go
+++ b/formatter.go
@@ -73,3 +73,5 @@ func (f *defaultFormatter) Format(counters map[string]*Counter) []byte {
 
 	return buf.Bytes()
 }
+
+var _ Formatter = (*defaultFormatter)(nil)


### PR DESCRIPTION
This check in readme will clearly show users an interface that needs to be implemented. 

And also type-check all intended implementations of `Formatter` to prevent them from breaking.