### PR TITLE
feature: add group counter

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,0 +1,81 @@
+package gometer
+
+import (
+	"fmt"
+	"sync"
+)
+
+// GroupCounter represents a collection of grouped counters.
+type GroupCounter struct {
+	mu              sync.Mutex
+	counters        map[string]*Counter
+	prefix          string
+	prefixSeparator string
+}
+
+// WithPrefix returns a group counter with a base prefix.
+//
+// During the registration a group of counters in the metrics collection, the base
+// prefix will be added to each counter name in this group.
+func (g *GroupCounter) WithPrefix(format string, v ...interface{}) *GroupCounter {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.prefix = fmt.Sprintf(format, v...)
+
+	return g
+}
+
+// WithSeparator returns a group counter with a prefix separator.
+//
+// prefixSeparator determines how base prefix will be separated from the counter name.
+func (g *GroupCounter) WithSeparator(prefixSeparator string) *GroupCounter {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.prefixSeparator = prefixSeparator
+
+	return g
+}
+
+// Separator returns a prefix separator for the group.
+func (g *GroupCounter) Separator() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.prefixSeparator
+}
+
+// Prefix returns a base prefix for a group counter.
+func (g *GroupCounter) Prefix() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.prefix
+}
+
+// Add adds new counter in the group of counters.
+func (g *GroupCounter) Add(counterName string, counter *Counter) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.counters[counterName] = counter
+}
+
+// Get returns a counter from the group of counters.
+func (g *GroupCounter) Get(counterName string) *Counter {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.counters[counterName]
+}
+
+// Counters returns a collection of grouped counters with a formatted names.
+//
+// The name of the formatted counter will be constructed as a group prefix + a prefix
+// separator + an actual counter name.
+func (g *GroupCounter) Counters() map[string]*Counter {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	counters := make(map[string]*Counter, len(g.counters))
+	for name, counter := range g.counters {
+		counters[g.prefix+g.prefixSeparator+name] = counter
+	}
+
+	return counters
+}

--- a/group.go
+++ b/group.go
@@ -1,81 +1,32 @@
 package gometer
 
-import (
-	"fmt"
-	"sync"
-)
+import "sync"
 
-// GroupCounter represents a collection of grouped counters.
-type GroupCounter struct {
-	mu              sync.Mutex
-	counters        map[string]*Counter
-	prefix          string
-	prefixSeparator string
-}
-
-// WithPrefix returns a group counter with a base prefix.
-//
-// During the registration a group of counters in the metrics collection, the base
-// prefix will be added to each counter name in this group.
-func (g *GroupCounter) WithPrefix(format string, v ...interface{}) *GroupCounter {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.prefix = fmt.Sprintf(format, v...)
-
-	return g
-}
-
-// WithSeparator returns a group counter with a prefix separator.
-//
-// prefixSeparator determines how base prefix will be separated from the counter name.
-func (g *GroupCounter) WithSeparator(prefixSeparator string) *GroupCounter {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.prefixSeparator = prefixSeparator
-
-	return g
-}
-
-// Separator returns a prefix separator for the group.
-func (g *GroupCounter) Separator() string {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.prefixSeparator
-}
-
-// Prefix returns a base prefix for a group counter.
-func (g *GroupCounter) Prefix() string {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.prefix
+// CountersGroup represents a collection of grouped counters.
+type CountersGroup struct {
+	mu       sync.Mutex
+	counters map[string]*Counter
+	prefix   string
 }
 
 // Add adds new counter in the group of counters.
-func (g *GroupCounter) Add(counterName string, counter *Counter) {
+// If a counter with `counterName` exists, it'll be overwritten.
+func (g *CountersGroup) Add(counterName string, counter *Counter) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.counters[counterName] = counter
+	g.counters[g.prefix+counterName] = counter
 }
 
 // Get returns a counter from the group of counters.
-func (g *GroupCounter) Get(counterName string) *Counter {
+func (g *CountersGroup) Get(counterName string) *Counter {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.counters[counterName]
+	return g.counters[g.prefix+counterName]
 }
 
-// Counters returns a collection of grouped counters with a formatted names.
-//
-// The name of the formatted counter will be constructed as a group prefix + a prefix
-// separator + an actual counter name.
-func (g *GroupCounter) Counters() map[string]*Counter {
+// Counters returns a collection of grouped counters.
+func (g *CountersGroup) Counters() map[string]*Counter {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-
-	counters := make(map[string]*Counter, len(g.counters))
-	for name, counter := range g.counters {
-		counters[g.prefix+g.prefixSeparator+name] = counter
-	}
-
-	return counters
+	return g.counters
 }

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,57 @@
+package gometer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupCounterWithPrefix(t *testing.T) {
+	metrics := New()
+
+	group := metrics.Group().WithPrefix("foo.%s.baz", "bar")
+
+	require.NotNil(t, group)
+	assert.Equal(t, "foo.bar.baz", group.Prefix())
+}
+
+func TestGroupCounterAdd(t *testing.T) {
+	metrics := New()
+	group := metrics.Group().WithPrefix("foo")
+
+	counter := Counter{}
+	counter.Add(10)
+	group.Add("bar", &counter)
+
+	got := group.Get("bar")
+	require.NotNil(t, got)
+	assert.Equal(t, int64(10), got.Get())
+}
+
+func TestGroupCounterWithSeparator(t *testing.T) {
+	metrics := New()
+	group := metrics.Group().WithPrefix("foo.%s", "bar").WithSeparator(".")
+	require.NotNil(t, group)
+
+	assert.Equal(t, ".", group.Separator())
+}
+
+func TestGroupCounterCounters(t *testing.T) {
+	metrics := New()
+	group := metrics.Group().WithPrefix("foo.%s", "bar").WithSeparator(".")
+	require.NotNil(t, group)
+
+	bazCounter := Counter{}
+	bazCounter.Set(10)
+
+	group.Add("baz", &bazCounter)
+
+	groupCounters := group.Counters()
+	require.Len(t, groupCounters, 1)
+
+	gotBazCounter := groupCounters["foo.bar.baz"]
+	require.NotNil(t, gotBazCounter)
+
+	assert.Equal(t, int64(10), gotBazCounter.Get())
+}

--- a/group_test.go
+++ b/group_test.go
@@ -7,18 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGroupCounterWithPrefix(t *testing.T) {
+func TestCountersGroupAdd(t *testing.T) {
 	metrics := New()
-
-	group := metrics.Group().WithPrefix("foo.%s.baz", "bar")
-
-	require.NotNil(t, group)
-	assert.Equal(t, "foo.bar.baz", group.Prefix())
-}
-
-func TestGroupCounterAdd(t *testing.T) {
-	metrics := New()
-	group := metrics.Group().WithPrefix("foo")
+	group := metrics.Group("foo.")
 
 	counter := Counter{}
 	counter.Add(10)
@@ -29,17 +20,10 @@ func TestGroupCounterAdd(t *testing.T) {
 	assert.Equal(t, int64(10), got.Get())
 }
 
-func TestGroupCounterWithSeparator(t *testing.T) {
+func TestCountersGroupCounters(t *testing.T) {
 	metrics := New()
-	group := metrics.Group().WithPrefix("foo.%s", "bar").WithSeparator(".")
-	require.NotNil(t, group)
 
-	assert.Equal(t, ".", group.Separator())
-}
-
-func TestGroupCounterCounters(t *testing.T) {
-	metrics := New()
-	group := metrics.Group().WithPrefix("foo.%s", "bar").WithSeparator(".")
+	group := metrics.Group("%s.", "foo")
 	require.NotNil(t, group)
 
 	bazCounter := Counter{}
@@ -50,7 +34,7 @@ func TestGroupCounterCounters(t *testing.T) {
 	groupCounters := group.Counters()
 	require.Len(t, groupCounters, 1)
 
-	gotBazCounter := groupCounters["foo.bar.baz"]
+	gotBazCounter := groupCounters["foo.baz"]
 	require.NotNil(t, gotBazCounter)
 
 	assert.Equal(t, int64(10), gotBazCounter.Get())

--- a/meter.go
+++ b/meter.go
@@ -82,11 +82,11 @@ func registerCounter(metrics *Metrics, counterName string, counter *Counter) err
 
 // RegisterGroup registers a collection of counters in the metric collection, returns
 // an error if a counter with such name exists.
-func (m *Metrics) RegisterGroup(group *GroupCounter) error {
+func (m *Metrics) RegisterGroup(group *CountersGroup) error {
 	return registerGroup(m, group)
 }
 
-func registerGroup(metrics *Metrics, group *GroupCounter) error {
+func registerGroup(metrics *Metrics, group *CountersGroup) error {
 	counters := group.Counters()
 
 	for name, counter := range counters {
@@ -117,9 +117,13 @@ func (m *Metrics) SetErrorHandler(e ErrorHandler) {
 	m.errHandler = e
 }
 
-// Group returns new group counter.
-func (m *Metrics) Group() *GroupCounter {
-	return &GroupCounter{
+// Group returns new counters group.
+//
+// During the registration a group of counters in the metrics collection, the base
+// prefix will be added to the each counter name in this group.
+func (m *Metrics) Group(format string, v ...interface{}) *CountersGroup {
+	return &CountersGroup{
+		prefix:   fmt.Sprintf(format, v...),
 		counters: make(map[string]*Counter),
 	}
 }
@@ -256,15 +260,19 @@ func StartFileWriter(ctx context.Context, p FileWriterParams) {
 	go startFileWriter(ctx, std, p)
 }
 
-// Group returns new group counter.
-func Group() *GroupCounter {
-	return &GroupCounter{
+// Group returns new group counter for the default metrics collection..
+//
+// During the registration a group of counters in the metrics collection, the base
+// prefix will be added to each counter name in this group.
+func Group(format string, v ...interface{}) *CountersGroup {
+	return &CountersGroup{
+		prefix:   fmt.Sprintf(format, v),
 		counters: make(map[string]*Counter),
 	}
 }
 
 // RegisterGroup registers a collection of counters in the default metric collection,
 // returns an error if a counter with such name exists.
-func RegisterGroup(group *GroupCounter) error {
+func RegisterGroup(group *CountersGroup) error {
 	return registerGroup(std, group)
 }

--- a/meter_test.go
+++ b/meter_test.go
@@ -167,6 +167,12 @@ func TestMetricsDefault(t *testing.T) {
 	counter := Get("default_metrics_counter")
 	require.NotNil(t, counter)
 	assert.Equal(t, int64(10), counter.Get())
+
+	group := Group()
+	assert.NotNil(t, group)
+
+	err = RegisterGroup(group)
+	assert.Nil(t, err)
 }
 
 type mockErrorHandler struct{}
@@ -204,4 +210,33 @@ func TestMetricsGetCounter(t *testing.T) {
 	c = metrics.Get("get_counter")
 	require.NotNil(t, c)
 	assert.Equal(t, int64(10), c.Get())
+}
+
+func TestMetricsGroup(t *testing.T) {
+	metrics := New()
+
+	group := metrics.Group()
+	assert.NotNil(t, group)
+}
+
+func TestMetricsRegisterGroup(t *testing.T) {
+	metrics := New()
+
+	group := metrics.Group().WithPrefix("foo").WithSeparator(".")
+
+	barCounter := Counter{}
+	barCounter.Add(100)
+
+	bazCounter := Counter{}
+	bazCounter.Add(140)
+
+	group.Add("bar", &barCounter)
+	group.Add("baz", &bazCounter)
+
+	err := metrics.RegisterGroup(group)
+	require.Nil(t, err)
+
+	gotBar := metrics.Get("foo.bar")
+	require.NotNil(t, gotBar)
+	assert.Equal(t, int64(100), gotBar.Get())
 }

--- a/meter_test.go
+++ b/meter_test.go
@@ -168,7 +168,7 @@ func TestMetricsDefault(t *testing.T) {
 	require.NotNil(t, counter)
 	assert.Equal(t, int64(10), counter.Get())
 
-	group := Group()
+	group := Group("foo.%s", "bar")
 	assert.NotNil(t, group)
 
 	err = RegisterGroup(group)
@@ -215,14 +215,14 @@ func TestMetricsGetCounter(t *testing.T) {
 func TestMetricsGroup(t *testing.T) {
 	metrics := New()
 
-	group := metrics.Group()
+	group := metrics.Group("foo")
 	assert.NotNil(t, group)
 }
 
 func TestMetricsRegisterGroup(t *testing.T) {
 	metrics := New()
 
-	group := metrics.Group().WithPrefix("foo").WithSeparator(".")
+	group := metrics.Group("foo.")
 
 	barCounter := Counter{}
 	barCounter.Add(100)


### PR DESCRIPTION
A group counter allows to group counters by prefix. Also add an ability to
register a group of counters in the metric collection.