### PR TITLE
introduce `Counter` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func ExampleWriteToStdout() {
 	metrics.SetOutput(os.Stdout)
 	metrics.SetFormatter(gometer.NewFormatter("\n"))
 
-	c := gometer.Counter{}
+	c := gometer.DefaultCounter{}
 	c.Add(1)
 	if err := metrics.Register("http_requests_total", &c); err != nil {
 		fmt.Println(err.Error())
@@ -67,7 +67,7 @@ import (
 
 type simpleFormatter struct{}
 
-func (f *simpleFormatter) Format(counters map[string]*gometer.Counter) []byte {
+func (f *simpleFormatter) Format(counters map[string]gometer.Counter) []byte {
 	var buf bytes.Buffer
 	for name, counter := range counters {
 		line := fmt.Sprintf("%v, %v", name, counter.Get()) + "\n"
@@ -83,7 +83,7 @@ func ExampleSimpleFormatter() {
 	metrics.SetOutput(os.Stdout)
 	metrics.SetFormatter(new(simpleFormatter))
 
-	c := gometer.Counter{}
+	c := gometer.DefaultCounter{}
 	c.Add(100)
 	if err := metrics.Register("http_requests_total", &c); err != nil {
 		fmt.Println(err.Error())
@@ -99,7 +99,7 @@ func ExampleSimpleFormatter() {
 
 type sortByNameFormatter struct{}
 
-func (f *sortByNameFormatter) Format(counters map[string]*gometer.Counter) []byte {
+func (f *sortByNameFormatter) Format(counters map[string]gometer.Counter) []byte {
 	var buf bytes.Buffer
 
 	var names []string
@@ -124,21 +124,21 @@ func ExampleSortByNameFormatter() {
 	metrics.SetOutput(os.Stdout)
 	metrics.SetFormatter(new(sortByNameFormatter))
 
-	adder := gometer.Counter{}
+	adder := gometer.DefaultCounter{}
 	adder.Add(10)
 	if err := metrics.Register("adder", &adder); err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	setter := gometer.Counter{}
+	setter := gometer.DefaultCounter{}
 	setter.Set(-1)
 	if err := metrics.Register("setter", &setter); err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	inc := gometer.Counter{}
+	inc := gometer.DefaultCounter{}
 	inc.Add(1)
 	if err := metrics.Register("inc", &inc); err != nil {
 		fmt.Println(err.Error())

--- a/_examples/formatter_test.go
+++ b/_examples/formatter_test.go
@@ -11,7 +11,7 @@ import (
 
 type simpleFormatter struct{}
 
-func (f *simpleFormatter) Format(counters map[string]*gometer.Counter) []byte {
+func (f *simpleFormatter) Format(counters map[string]gometer.Counter) []byte {
 	var buf bytes.Buffer
 	for name, counter := range counters {
 		line := fmt.Sprintf("%v, %v", name, counter.Get()) + "\n"
@@ -27,7 +27,7 @@ func ExampleSimpleFormatter() {
 	metrics.SetOutput(os.Stdout)
 	metrics.SetFormatter(new(simpleFormatter))
 
-	c := gometer.Counter{}
+	c := gometer.DefaultCounter{}
 	c.Add(100)
 	if err := metrics.Register("http_requests_total", &c); err != nil {
 		fmt.Println(err.Error())
@@ -43,7 +43,7 @@ func ExampleSimpleFormatter() {
 
 type sortByNameFormatter struct{}
 
-func (f *sortByNameFormatter) Format(counters map[string]*gometer.Counter) []byte {
+func (f *sortByNameFormatter) Format(counters map[string]gometer.Counter) []byte {
 	var buf bytes.Buffer
 
 	var names []string
@@ -68,21 +68,21 @@ func ExampleSortByNameFormatter() {
 	metrics.SetOutput(os.Stdout)
 	metrics.SetFormatter(new(sortByNameFormatter))
 
-	adder := gometer.Counter{}
+	adder := gometer.DefaultCounter{}
 	adder.Add(10)
 	if err := metrics.Register("adder", &adder); err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	setter := gometer.Counter{}
+	setter := gometer.DefaultCounter{}
 	setter.Set(-1)
 	if err := metrics.Register("setter", &setter); err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	inc := gometer.Counter{}
+	inc := gometer.DefaultCounter{}
 	inc.Add(1)
 	if err := metrics.Register("inc", &inc); err != nil {
 		fmt.Println(err.Error())

--- a/_examples/stdout_test.go
+++ b/_examples/stdout_test.go
@@ -13,7 +13,7 @@ func ExampleWriteToStdout() {
 	metrics.SetOutput(os.Stdout)
 	metrics.SetFormatter(gometer.NewFormatter("\n"))
 
-	c := gometer.Counter{}
+	c := gometer.DefaultCounter{}
 	c.Add(1)
 	if err := metrics.Register("http_requests_total", &c); err != nil {
 		fmt.Println(err.Error())

--- a/counter.go
+++ b/counter.go
@@ -3,21 +3,33 @@ package gometer
 import "sync/atomic"
 
 // Counter represents a kind of metric.
-type Counter struct {
+type Counter interface {
+	// Add adds the corresponding value to counter.
+	Add(v int64)
+
+	// Get returns the corresponding value for counter.
+	Get() int64
+
+	// Set sets the value to counter. Value can be negative.
+	Set(v int64)
+}
+
+// DefaultCounter implements Counter.
+type DefaultCounter struct {
 	val int64
 }
 
-// Add adds the corresponding value to counter.
-func (c *Counter) Add(val int64) {
+// Add implements Counter.Add
+func (c *DefaultCounter) Add(val int64) {
 	atomic.AddInt64(&c.val, val)
 }
 
-// Get returns the corresponding value for counter.
-func (c *Counter) Get() int64 {
+// Get implements Counter.Get
+func (c *DefaultCounter) Get() int64 {
 	return atomic.LoadInt64(&c.val)
 }
 
-// Set sets the value to counter. Value can be negative.
-func (c *Counter) Set(val int64) {
+// Set implements Counter.Set
+func (c *DefaultCounter) Set(val int64) {
 	atomic.StoreInt64(&c.val, val)
 }

--- a/counter_test.go
+++ b/counter_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestCounterAdd(t *testing.T) {
-	c := Counter{}
+	c := DefaultCounter{}
 	c.Add(10)
 	assert.Equal(t, int64(10), c.Get())
 }
 
 func TestCounterSet(t *testing.T) {
-	c := Counter{}
+	c := DefaultCounter{}
 	c.Set(10)
 	assert.Equal(t, int64(10), c.Get())
 

--- a/formatter.go
+++ b/formatter.go
@@ -10,7 +10,7 @@ import (
 type Formatter interface {
 	// Format is defined how metrics will be dumped
 	// to output destination.
-	Format(counters map[string]*Counter) []byte
+	Format(counters map[string]Counter) []byte
 }
 
 // NewFormatter returns new default formatter.
@@ -30,7 +30,7 @@ func NewFormatter(lineSeparator string) Formatter {
 }
 
 type sortedMap struct {
-	m map[string]*Counter
+	m map[string]Counter
 	s []string
 }
 
@@ -46,7 +46,7 @@ func (sm *sortedMap) Swap(i, j int) {
 	sm.s[i], sm.s[j] = sm.s[j], sm.s[i]
 }
 
-func sortedKeys(m map[string]*Counter) []string {
+func sortedKeys(m map[string]Counter) []string {
 	sm := new(sortedMap)
 	sm.m = m
 	sm.s = make([]string, len(m))
@@ -63,7 +63,7 @@ type defaultFormatter struct {
 	lineSeparator string
 }
 
-func (f *defaultFormatter) Format(counters map[string]*Counter) []byte {
+func (f *defaultFormatter) Format(counters map[string]Counter) []byte {
 	var buf bytes.Buffer
 
 	for _, n := range sortedKeys(counters) {

--- a/group.go
+++ b/group.go
@@ -5,27 +5,27 @@ import "sync"
 // CountersGroup represents a collection of grouped counters.
 type CountersGroup struct {
 	mu       sync.Mutex
-	counters map[string]*Counter
+	counters map[string]*DefaultCounter
 	prefix   string
 }
 
 // Add adds new counter in the group of counters.
 // If a counter with `counterName` exists, it'll be overwritten.
-func (g *CountersGroup) Add(counterName string, counter *Counter) {
+func (g *CountersGroup) Add(counterName string, counter *DefaultCounter) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.counters[g.prefix+counterName] = counter
 }
 
 // Get returns a counter from the group of counters.
-func (g *CountersGroup) Get(counterName string) *Counter {
+func (g *CountersGroup) Get(counterName string) *DefaultCounter {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.counters[g.prefix+counterName]
 }
 
 // Counters returns a collection of grouped counters.
-func (g *CountersGroup) Counters() map[string]*Counter {
+func (g *CountersGroup) Counters() map[string]*DefaultCounter {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.counters

--- a/group_test.go
+++ b/group_test.go
@@ -11,7 +11,7 @@ func TestCountersGroupAdd(t *testing.T) {
 	metrics := New()
 	group := metrics.Group("foo.")
 
-	counter := Counter{}
+	counter := DefaultCounter{}
 	counter.Add(10)
 	group.Add("bar", &counter)
 
@@ -26,7 +26,7 @@ func TestCountersGroupCounters(t *testing.T) {
 	group := metrics.Group("%s.", "foo")
 	require.NotNil(t, group)
 
-	bazCounter := Counter{}
+	bazCounter := DefaultCounter{}
 	bazCounter.Set(10)
 
 	group.Add("baz", &bazCounter)

--- a/meter.go
+++ b/meter.go
@@ -15,7 +15,7 @@ import (
 type Metrics struct {
 	mu         sync.Mutex
 	out        io.Writer
-	counters   map[string]*Counter
+	counters   map[string]Counter
 	formatter  Formatter
 	errHandler ErrorHandler
 }
@@ -34,7 +34,7 @@ var std = New()
 func New() *Metrics {
 	m := &Metrics{
 		out:       os.Stderr,
-		counters:  make(map[string]*Counter),
+		counters:  make(map[string]Counter),
 		formatter: NewFormatter("\n"),
 	}
 	return m
@@ -64,11 +64,11 @@ func (m *Metrics) Formatter() Formatter {
 
 // Register registers new counter in metric collection, returns error if
 // counter with such name exists.
-func (m *Metrics) Register(counterName string, c *Counter) error {
+func (m *Metrics) Register(counterName string, c *DefaultCounter) error {
 	return registerCounter(m, counterName, c)
 }
 
-func registerCounter(metrics *Metrics, counterName string, counter *Counter) error {
+func registerCounter(metrics *Metrics, counterName string, counter Counter) error {
 	metrics.mu.Lock()
 	defer metrics.mu.Unlock()
 
@@ -98,11 +98,11 @@ func registerGroup(metrics *Metrics, group *CountersGroup) error {
 }
 
 // Get returns counter by name or nil if counter doesn't exist.
-func (m *Metrics) Get(counterName string) *Counter {
+func (m *Metrics) Get(counterName string) Counter {
 	return getCounter(m, counterName)
 }
 
-func getCounter(m *Metrics, counterName string) *Counter {
+func getCounter(m *Metrics, counterName string) Counter {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	c := m.counters[counterName]
@@ -124,7 +124,7 @@ func (m *Metrics) SetErrorHandler(e ErrorHandler) {
 func (m *Metrics) Group(format string, v ...interface{}) *CountersGroup {
 	return &CountersGroup{
 		prefix:   fmt.Sprintf(format, v...),
-		counters: make(map[string]*Counter),
+		counters: make(map[string]*DefaultCounter),
 	}
 }
 
@@ -228,12 +228,12 @@ func SetFormatter(f Formatter) {
 
 // Register registers new counter in metric collection, returns error if
 // counter with such name exists.
-func Register(counterName string, c *Counter) error {
+func Register(counterName string, c Counter) error {
 	return registerCounter(std, counterName, c)
 }
 
 // Get returns counter by name or nil if counter doesn't exist.
-func Get(counterName string) *Counter {
+func Get(counterName string) Counter {
 	return getCounter(std, counterName)
 }
 
@@ -267,7 +267,7 @@ func StartFileWriter(ctx context.Context, p FileWriterParams) {
 func Group(format string, v ...interface{}) *CountersGroup {
 	return &CountersGroup{
 		prefix:   fmt.Sprintf(format, v...),
-		counters: make(map[string]*Counter),
+		counters: make(map[string]*DefaultCounter),
 	}
 }
 

--- a/meter_test.go
+++ b/meter_test.go
@@ -22,7 +22,7 @@ func TestMetricsStartFileWriter(t *testing.T) {
 		metrics.StartFileWriter(nil, FileWriterParams{})
 	})
 
-	inc := Counter{}
+	inc := DefaultCounter{}
 	inc.Add(10)
 	err := metrics.Register("add_num", &inc)
 	require.Nil(t, err)
@@ -42,7 +42,7 @@ func TestMetricsStartFileWriter(t *testing.T) {
 	})
 	cancel()
 
-	inc1 := Counter{}
+	inc1 := DefaultCounter{}
 	inc1.Add(4)
 	err = metrics.Register("inc_num", &inc1)
 	require.Nil(t, err)
@@ -96,7 +96,7 @@ func TestMetricsSetFormatter(t *testing.T) {
 	metrics.SetOutput(file)
 	metrics.SetFormatter(NewFormatter("\n"))
 
-	c := Counter{}
+	c := DefaultCounter{}
 	c.Add(10)
 	err := metrics.Register("test_counter", &c)
 	require.Nil(t, err)
@@ -140,7 +140,7 @@ func TestMetricsDefault(t *testing.T) {
 	SetFormatter(NewFormatter("\n"))
 	assert.NotNil(t, std.formatter)
 
-	c := Counter{}
+	c := DefaultCounter{}
 	c.Add(10)
 	err := Register("default_metrics_counter", &c)
 	require.Nil(t, err)
@@ -189,7 +189,7 @@ func TestMetricsSetErrorHandler(t *testing.T) {
 
 func TestMetricsExistingCounter(t *testing.T) {
 	metrics := New()
-	counter := Counter{}
+	counter := DefaultCounter{}
 	err := metrics.Register("existing_metrics", &counter)
 	require.Nil(t, err)
 
@@ -202,7 +202,7 @@ func TestMetricsGetCounter(t *testing.T) {
 	c := metrics.Get("not_existing_counter")
 	require.Nil(t, c)
 
-	counter := Counter{}
+	counter := DefaultCounter{}
 	counter.Set(10)
 	err := metrics.Register("get_counter", &counter)
 	require.Nil(t, err)
@@ -224,10 +224,10 @@ func TestMetricsRegisterGroup(t *testing.T) {
 
 	group := metrics.Group("foo.")
 
-	barCounter := Counter{}
+	barCounter := DefaultCounter{}
 	barCounter.Add(100)
 
-	bazCounter := Counter{}
+	bazCounter := DefaultCounter{}
 	bazCounter.Add(140)
 
 	group.Add("bar", &barCounter)


### PR DESCRIPTION
Previously used `Counter` struct was rename to `DefaultCounter`.